### PR TITLE
Allow a device to generically define its own headers

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -553,6 +553,11 @@ all_objects := \
     $(proto_generated_objects) \
     $(addprefix $(TOPDIR)$(LOCAL_PATH)/,$(LOCAL_PREBUILT_OBJ_FILES))
 
+## Allow a device's own headers to take precedence over global ones
+ifneq ($(TARGET_SPECIFIC_HEADER_PATH),)
+LOCAL_C_INCLUDES += $(TOPDIR)$(TARGET_SPECIFIC_HEADER_PATH)
+endif
+
 LOCAL_C_INCLUDES += $(TOPDIR)$(LOCAL_PATH) $(intermediates)
 
 ifndef LOCAL_SDK_VERSION


### PR DESCRIPTION
We have a few cases of devices including specific versions of projects
just because of modified headers (msm_mdp.h comes to mind), and I just
had enough of ifdeffing header files for specific cases (the P990 needs
a lot of these).
Now... if a target defines a TARGET_SPECIFIC_HEADER_PATH, any headers in
there will take precedence over the standard ones; for example, on the
p990, I have

TARGET_SPECIFIC_HEADER_PATH := device/lge/p990/include

which makes, for example, the
device/lge/p990/include/hardware_legacy/AudioHardwareInterface.h be
used instead of
hardware/libhardware_legacy/include/hardware_legacy/AudioHardwareInterface.h
whenever a source file uses <hardware_legacy/AudioHardwareInterface.h>

Change-Id: I41b62668b60e3f62a6ebd3738d8d2675103a81e6a
