### PR TITLE
fix up the compiler flags for good

### DIFF
--- a/core/combo/select.mk
+++ b/core/combo/select.mk
@@ -46,14 +46,14 @@ $(combo_target)HAVE_STRLCPY := 0
 $(combo_target)HAVE_STRLCAT := 0
 $(combo_target)HAVE_KERNEL_MODULES := 0
 
-ifeq ($(TARGET_USE_O3),true)
 $(combo_target)GLOBAL_CFLAGS := -fno-exceptions -Wno-multichar
+ifeq ($(TARGET_USE_O3),true)
 $(combo_target)RELEASE_CFLAGS := -O3 -g -fno-strict-aliasing
-else
-$(combo_target)GLOBAL_CFLAGS := -O2 -g -fno-strict-aliasing
-$(combo_target)RELEASE_CFLAGS := 
-endif
 $(combo_target)GLOBAL_LDFLAGS := -Wl,-O2
+else
+$(combo_target)RELEASE_CFLAGS := -O2 -g -fno-strict-aliasing
+$(combo_target)GLOBAL_LDFLAGS :=
+endif
 $(combo_target)GLOBAL_ARFLAGS := crsP
 
 $(combo_target)EXECUTABLE_SUFFIX :=


### PR DESCRIPTION
Commit 399cf571 has been completely fucked up, additionally to both my previous fixes (ifneq->ifeq, 0->O) the GLOBAL_CFLAGS and RELEASE_CFLAGS have been mixed up.
Due to the previous errors this one has been covered up, but now it leads to build errors for non-O3 builds. I didn't notice that until now as I've been testing the fixed O3 flag only.
Note that before my commits the compiler always used O3, regardless  of TARGET_USE_O3.

I've reordered and fixed the commit now, this should finally match the intention of @aaronpoweruser.
