### PR TITLE
new variable TARGET_RECOVERY_FSTAB

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -603,7 +603,13 @@ recovery_resources_common := $(call include-path-for, recovery)/res
 recovery_resources_private := $(strip $(wildcard $(TARGET_DEVICE_DIR)/recovery/res))
 recovery_resource_deps := $(shell find $(recovery_resources_common) \
   $(recovery_resources_private) -type f)
-recovery_fstab := $(strip $(wildcard $(TARGET_DEVICE_DIR)/recovery.fstab))
+
+ifneq ($(TARGET_RECOVERY_FSTAB),)
+  recovery_fstab := $(strip $(wildcard $(TARGET_RECOVERY_FSTAB)))
+else
+  recovery_fstab := $(strip $(wildcard $(TARGET_DEVICE_DIR)/recovery.fstab))
+endif
+
 # Named '.dat' so we don't attempt to use imgdiff for patching it.
 RECOVERY_RESOURCE_ZIP := $(TARGET_OUT)/etc/recovery-resource.dat
 


### PR DESCRIPTION
Currently the source file recovery.fstab has to be located
in $(TARGET_DEVICE_DIR)/recovery.fstab).

To allow multiple similar CM products to share one recovery.fstab
file this patch introduces the variable TARGET_RECOVERY_FSTAB.

Change-Id: I51961f5a1665023001c9857e13008a2ca44529ee

Conflicts:
    core/Makefile
