### PR TITLE
apns-conf.xml: Let products/device.mk decide this

### DIFF
--- a/target/product/full_base_telephony.mk
+++ b/target/product/full_base_telephony.mk
@@ -26,8 +26,5 @@ PRODUCT_PROPERTY_OVERRIDES := \
     keyguard.no_require_sim=true \
     ro.com.android.dataroaming=false
 
-PRODUCT_COPY_FILES := \
-    vendor/pa/prebuilt/common/etc/apns-conf.xml:system/etc/apns-conf.xml
-
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/telephony.mk)


### PR DESCRIPTION
Pesky line overwrites vendor/pa/products/device.mk apns-conf.xml distinguishing so it only pulled gsm apns and not allow .mk to choose

thank you @trvrlol
