### PR TITLE
Makefile : Remove Conflicts Cause By init.rc

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -674,7 +674,6 @@ $(TARGET_RECOVERY_ROOT_TIMESTAMP): \
 	@echo -e ${CL_CYN}"Copying baseline ramdisk..."${CL_RST}
 	$(hide) cp -R $(TARGET_ROOT_OUT) $(TARGET_RECOVERY_OUT)
 	@echo -e ${CL_CYN}"Modifying ramdisk contents..."${CL_RST}
-	$(hide) rm -f $(TARGET_RECOVERY_ROOT_OUT)/init*.rc
 	$(hide) cp -f $(recovery_initrc) $(TARGET_RECOVERY_ROOT_OUT)/init.rc
 
 	$(hide) -cp $(TARGET_ROOT_OUT)/init.recovery.*.rc $(TARGET_RECOVERY_ROOT_OUT)/


### PR DESCRIPTION
Remove 1 rm Line to Resolve when Building Recovery.. This is the common problem for all PA Builders..
This Will Fix the result of Error 1 cause by " Cannot Copy Init.rc "

Signed By : TrinityHaxxorX@XDA ( Trinityhaxxor@gmail.com )
